### PR TITLE
Remove libffi dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,9 @@ numerous Pico drivers.
     Implements continuous gap-less streaming on top of `PicoDevice`.
 
 ## Prerequisites
-`pico-driver` uses a C library called `libffi` to call into older Pico
-drivers that don't allow us to pass context through callbacks. To build this
-you will need a working C compiler and on Unix based platforms you'll also
-[require `automake`, and
-`autoconf`](https://github.com/meatysolutions/pico-sdk/issues/5).
-
-On linux `pico-enumeration` [requires `libudev-dev`](https://github.com/meatysolutions/pico-sdk/blob/700ab24efe81063316baffff638988cf626c6ffe/.github/workflows/build-and-publish.yml#L32).
+On linux `pico-enumeration` [requires
+`libudev-dev`](https://github.com/meatysolutions/pico-sdk/blob/700ab24efe81063316baffff638988cf626c6ffe/.github/workflows/build-and-publish.yml#L32)
+to be installed.
 
 ## Tests
 Some tests open and stream from devices and these fail if devices are not available, for example when run in CI.

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "pico-common"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.0"
+version = "0.3.1"
 
 [lib]
 crate-type = ["lib"]

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "pico-device"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.0"
+version = "0.3.1"
 
 [lib]
 crate-type = ["lib"]
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 
 [dependencies]
 parking_lot = "0.11"
-pico-common = {path = "../common", version = "0.3.0"}
-pico-driver = {path = "../driver", version = "0.3.0"}
+pico-common = {path = "../common", version = "0.3.1"}
+pico-driver = {path = "../driver", version = "0.3.1"}
 serde = {version = "1.0", features = ["derive", "rc"], optional = true}
 tracing = {version = "0.1", features = ["attributes"]}

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "pico-download"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.0"
+version = "0.3.1"
 
 [lib]
 crate-type = ["lib"]
@@ -16,8 +16,8 @@ path = "src/lib.rs"
 [dependencies]
 directories = "3.0"
 http_req = "^0.7"
-pico-common = {path = "../common", version = "0.3.0"}
-pico-driver = {path = "../driver", version = "0.3.0"}
+pico-common = {path = "../common", version = "0.3.1"}
+pico-driver = {path = "../driver", version = "0.3.1"}
 ring = "0.16"
 thiserror = "^1.0"
 

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "pico-driver"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.0"
+version = "0.3.1"
 
 [lib]
 crate-type = ["lib"]
@@ -18,8 +18,8 @@ c_vec = "2.0"
 lazy_static = "1.4"
 libloading = "0.7"
 parking_lot = "0.11"
-pico-common = {path = "../common", version = "0.3.0"}
-pico-sys-dynamic = {path = "../sys", version = "0.3.0"}
+pico-common = {path = "../common", version = "0.3.1"}
+pico-sys-dynamic = {path = "../sys", version = "0.3.1"}
 thiserror = "^1.0"
 tracing = {version = "0.1", features = ["attributes"]}
 version-compare = "0.0.11"

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/lib.rs"
 [dependencies]
 c_vec = "2.0"
 lazy_static = "1.4"
-libffi = "1.0"
 libloading = "0.7"
 parking_lot = "0.11"
 pico-common = {path = "../common", version = "0.3.0"}

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -64,6 +64,7 @@ pub mod ps5000a;
 pub mod ps6000;
 pub mod ps6000a;
 mod resolution;
+mod trampoline;
 
 /// Covers the various errors encountered when attempting to load drivers
 #[derive(Error, Debug)]

--- a/driver/src/ps2000.rs
+++ b/driver/src/ps2000.rs
@@ -3,20 +3,113 @@ use crate::{
     get_version_string, EnumerationResult, PicoDriver,
 };
 use lazy_static::lazy_static;
-use libffi::high::ClosureMut6;
 use parking_lot::{Mutex, RwLock};
 use pico_common::{
     ChannelConfig, Driver, FromPicoStr, PicoChannel, PicoCoupling, PicoError, PicoInfo, PicoRange,
     PicoResult, PicoStatus, SampleConfig,
 };
 use pico_sys_dynamic::ps2000::PS2000Loader;
-use std::{collections::HashMap, pin::Pin, sync::Arc};
+use std::{collections::HashMap, pin::Pin, sync::Arc, time::Duration};
 
 type BufferMap = HashMap<PicoChannel, Arc<RwLock<Pin<Vec<i16>>>>>;
 
 lazy_static! {
     /// We store buffers so the ps2000 emulates the same API as the other drivers
     static ref BUFFERS: Mutex<HashMap<i16, BufferMap>> = Default::default();
+}
+
+struct CallbackRef {
+    handle: i16,
+    index: usize,
+}
+
+impl CallbackRef {
+    pub fn new(handle: i16) -> Self {
+        CallbackRef { handle, index: 0 }
+    }
+}
+
+#[derive(Default)]
+struct LockedCallbackRef {
+    inner: Mutex<Option<CallbackRef>>,
+}
+
+impl LockedCallbackRef {
+    fn start(&self, handle: i16) {
+        loop {
+            let mut inner = self.inner.lock();
+
+            if inner.is_none() {
+                *inner = Some(CallbackRef::new(handle));
+                return;
+            } else {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        }
+    }
+
+    fn callback(&self, overview_buffers: *const *const usize, n_values: usize) {
+        let mut inner = self.inner.lock();
+
+        if let Some(mut callback_ref) = inner.take() {
+            let buffer_pointers =
+                unsafe { std::slice::from_raw_parts::<*const usize>(overview_buffers, 4) };
+
+            let mut all_buffers = BUFFERS.lock();
+            let buffers = all_buffers
+                .get_mut(&callback_ref.handle)
+                .expect("Could not find buffers for this device");
+
+            let mut copy_data = |index: usize, ch: PicoChannel| {
+                let raw_data = unsafe {
+                    std::slice::from_raw_parts::<i16>(
+                        buffer_pointers[index] as *const i16,
+                        n_values,
+                    )
+                };
+                // fetch the buffer to copy the data into it
+                let mut ch_buf = buffers
+                    .get_mut(&ch)
+                    .expect("Could not find buffers for this channel")
+                    .write();
+
+                ch_buf[callback_ref.index..callback_ref.index + n_values]
+                    .copy_from_slice(&raw_data);
+            };
+
+            // ps2000 devices always have two channels so we just handle them manually
+            if !buffer_pointers[0].is_null() {
+                copy_data(0, PicoChannel::A)
+            }
+
+            if !buffer_pointers[2].is_null() {
+                copy_data(2, PicoChannel::B)
+            }
+
+            callback_ref.index += n_values as usize;
+            *inner = Some(callback_ref);
+        }
+    }
+
+    fn end(&self) -> Option<usize> {
+        let mut inner = self.inner.lock();
+        inner.take().map(|cb| cb.index)
+    }
+}
+
+lazy_static! {
+    static ref CALLBACK_REF: LockedCallbackRef = Default::default();
+}
+
+extern "C" fn streaming_callback(
+    overview_buffers: *mut *mut i16,
+    _overflow: i16,
+    _triggered_at: u32,
+    _triggered: i16,
+    _auto_stop: i16,
+    n_values: u32,
+) {
+    CALLBACK_REF.callback(overview_buffers as *const *const usize, n_values as usize);
 }
 
 pub struct PS2000Driver {
@@ -37,6 +130,7 @@ impl PS2000Driver {
     {
         let dependencies = load_dependencies(&path.as_ref());
         let bindings = unsafe { PS2000Loader::new(path)? };
+        unsafe { bindings.ps2000_apply_fix(0x1ced9168, 0x11e6) };
         Ok(PS2000Driver {
             bindings,
             _dependencies: dependencies,
@@ -48,23 +142,6 @@ impl PS2000Driver {
             -1 => Err(PicoStatus::OPERATION_FAILED),
             0 => Err(PicoStatus::NOT_FOUND),
             handle => Ok(handle),
-        }
-    }
-
-    /// Wraps the c callback with libffi so we can use closures
-    ///
-    /// This is required because the ps2000 driver doesn't pass a context object
-    /// through to the callback. Without a context object, we cannot know which
-    /// device the callback refers to. libffi lets us keep the context.
-    fn get_latest_streaming_values_wrap<F: FnMut(*mut *mut i16, i16, u32, i16, i16, u32)>(
-        &self,
-        handle: i16,
-        mut callback: F,
-    ) -> i16 {
-        let closure = ClosureMut6::new(&mut callback);
-        unsafe {
-            self.bindings
-                .ps2000_get_streaming_last_values(handle, Some(*closure.code_ptr()))
         }
     }
 }
@@ -104,7 +181,7 @@ impl PicoDriver for PS2000Driver {
 
                     let serial = self.get_unit_info(handle, PicoInfo::BATCH_AND_SERIAL)?;
                     let variant = self.get_unit_info(handle, PicoInfo::VARIANT_INFO)?;
-                    output.push(EnumerationResult { serial, variant });
+                    output.push(EnumerationResult { variant, serial });
                 }
                 Err(PicoStatus::NOT_FOUND) => break,
                 Err(e) => {
@@ -308,55 +385,16 @@ impl PicoDriver for PS2000Driver {
         _channels: &[PicoChannel],
         mut callback: Box<dyn FnMut(usize, usize) + 'a>,
     ) -> PicoResult<()> {
-        self.get_latest_streaming_values_wrap(
-            handle,
-            |overview_buffers: *mut *mut i16, _: i16, _: u32, _: i16, _: i16, n_values: u32| {
-                let buffer_pointers = unsafe {
-                    std::slice::from_raw_parts::<*const usize>(
-                        overview_buffers as *const *const usize,
-                        4,
-                    )
-                };
+        CALLBACK_REF.start(handle);
 
-                let mut all_buffers = BUFFERS.lock();
-                let buffers = all_buffers
-                    .get_mut(&handle)
-                    .expect("Could not find buffers for this device");
+        unsafe {
+            self.bindings
+                .ps2000_get_streaming_last_values(handle, Some(streaming_callback))
+        };
 
-                let mut copy_data = |index: usize, ch: PicoChannel| {
-                    let raw_data = unsafe {
-                        std::slice::from_raw_parts::<i16>(
-                            buffer_pointers[index] as *const i16,
-                            n_values as usize,
-                        )
-                    };
-                    // fetch the buffer to copy the data into it
-                    let mut ch_buf = buffers
-                        .get_mut(&ch)
-                        .expect("Could not find buffers for this channel")
-                        .write();
-
-                    // We need to resize the buffer so we can copy it
-                    // straight into ch_buf
-                    let mut raw_data = raw_data.to_vec();
-                    raw_data.resize(ch_buf.len(), 0);
-
-                    ch_buf.copy_from_slice(&raw_data);
-                };
-
-                // ps2000 devices always have two channels so we just handle them manually
-                if !buffer_pointers[0].is_null() {
-                    copy_data(0, PicoChannel::A)
-                }
-
-                if !buffer_pointers[2].is_null() {
-                    copy_data(2, PicoChannel::B)
-                }
-
-                // The data is always copied into the start of the buffer
-                callback(0, n_values as usize);
-            },
-        );
+        if let Some(sample_count) = CALLBACK_REF.end() {
+            callback(0, sample_count);
+        }
 
         Ok(())
     }

--- a/driver/src/ps2000a.rs
+++ b/driver/src/ps2000a.rs
@@ -30,6 +30,7 @@ impl PS2000ADriver {
     {
         let dependencies = load_dependencies(&path.as_ref());
         let bindings = unsafe { PS2000ALoader::new(path)? };
+        // Disables the splash screen on Windows
         unsafe { bindings.ps2000aApplyFix(0x1ced9168, 0x11e6) };
         Ok(PS2000ADriver {
             bindings,

--- a/driver/src/ps3000a.rs
+++ b/driver/src/ps3000a.rs
@@ -30,6 +30,7 @@ impl PS3000ADriver {
     {
         let dependencies = load_dependencies(&path.as_ref());
         let bindings = unsafe { PS3000ALoader::new(path)? };
+        // Disables the splash screen on Windows
         unsafe { bindings.ps3000aApplyFix(0x1ced9168, 0x11e6) };
         Ok(PS3000ADriver {
             bindings,

--- a/driver/src/ps3000a.rs
+++ b/driver/src/ps3000a.rs
@@ -1,9 +1,9 @@
 use crate::{
-    get_version_string, parse_enum_result,
     dependencies::{load_dependencies, LoadedDependencies},
+    get_version_string, parse_enum_result,
+    trampoline::split_closure,
     EnumerationResult, PicoDriver,
 };
-use libffi::high::ClosureMut8;
 use parking_lot::RwLock;
 use pico_common::{
     ChannelConfig, DownsampleMode, Driver, FromPicoStr, PicoChannel, PicoError, PicoInfo,
@@ -30,6 +30,7 @@ impl PS3000ADriver {
     {
         let dependencies = load_dependencies(&path.as_ref());
         let bindings = unsafe { PS3000ALoader::new(path)? };
+        unsafe { bindings.ps3000aApplyFix(0x1ced9168, 0x11e6) };
         Ok(PS3000ADriver {
             bindings,
             _dependencies: dependencies,
@@ -267,17 +268,16 @@ impl PicoDriver for PS3000ADriver {
         _channels: &[PicoChannel],
         mut callback: Box<dyn FnMut(usize, usize) + 'a>,
     ) -> PicoResult<()> {
-        let mut simplify_args = |_, sample_count, start_index, _, _, _, _, _| {
-            callback(start_index as usize, sample_count as usize);
-        };
-        let closure_mut = ClosureMut8::new(&mut simplify_args);
+        let mut simplify_args =
+            |_: i16, sample_count: i32, start_index: u32, _: i16, _: u32, _: i16, _: i16| {
+                callback(start_index as usize, sample_count as usize);
+            };
 
         let status = PicoStatus::from(unsafe {
-            self.bindings.ps3000aGetStreamingLatestValues(
-                handle,
-                Some(*closure_mut.code_ptr()),
-                std::ptr::null_mut(),
-            )
+            let (state, callback) = split_closure(&mut simplify_args);
+
+            self.bindings
+                .ps3000aGetStreamingLatestValues(handle, Some(callback), state)
         });
 
         match status {

--- a/driver/src/ps4000.rs
+++ b/driver/src/ps4000.rs
@@ -30,6 +30,7 @@ impl PS4000Driver {
     {
         let dependencies = load_dependencies(&path.as_ref());
         let bindings = unsafe { PS4000Loader::new(path)? };
+        // Disables the splash screen on Windows
         unsafe { bindings.ps4000ApplyFix(0x1ced9168, 0x11e6) };
         Ok(PS4000Driver {
             bindings,

--- a/driver/src/ps4000.rs
+++ b/driver/src/ps4000.rs
@@ -1,9 +1,9 @@
 use crate::{
-    get_version_string, parse_enum_result,
     dependencies::{load_dependencies, LoadedDependencies},
+    get_version_string, parse_enum_result,
+    trampoline::split_closure,
     EnumerationResult, PicoDriver,
 };
-use libffi::high::ClosureMut8;
 use parking_lot::RwLock;
 use pico_common::{
     ChannelConfig, Driver, FromPicoStr, PicoChannel, PicoError, PicoInfo, PicoRange, PicoResult,
@@ -30,6 +30,7 @@ impl PS4000Driver {
     {
         let dependencies = load_dependencies(&path.as_ref());
         let bindings = unsafe { PS4000Loader::new(path)? };
+        unsafe { bindings.ps4000ApplyFix(0x1ced9168, 0x11e6) };
         Ok(PS4000Driver {
             bindings,
             _dependencies: dependencies,
@@ -245,18 +246,16 @@ impl PicoDriver for PS4000Driver {
         _channels: &[PicoChannel],
         mut callback: Box<dyn FnMut(usize, usize) + 'a>,
     ) -> PicoResult<()> {
-        let mut simplify_args = |_, sample_count, start_index, _, _, _, _, _| {
-            callback(start_index as usize, sample_count as usize);
-        };
-
-        let closure = ClosureMut8::new(&mut simplify_args);
+        let mut simplify_args =
+            |_: i16, sample_count: i32, start_index: u32, _: i16, _: u32, _: i16, _: i16| {
+                callback(start_index as usize, sample_count as usize);
+            };
 
         let status = PicoStatus::from(unsafe {
-            self.bindings.ps4000GetStreamingLatestValues(
-                handle,
-                Some(*closure.code_ptr()),
-                std::ptr::null_mut(),
-            )
+            let (state, callback) = split_closure(&mut simplify_args);
+
+            self.bindings
+                .ps4000GetStreamingLatestValues(handle, Some(callback), state)
         });
 
         match status {

--- a/driver/src/ps4000a.rs
+++ b/driver/src/ps4000a.rs
@@ -75,6 +75,7 @@ impl PS4000ADriver {
     {
         let dependencies = load_dependencies(&path.as_ref());
         let bindings = unsafe { PS4000ALoader::new(path)? };
+        // Disables the splash screen on Windows
         unsafe { bindings.ps4000aApplyFix(0x1ced9168, 0x11e6) };
         Ok(PS4000ADriver {
             bindings,

--- a/driver/src/ps4000a.rs
+++ b/driver/src/ps4000a.rs
@@ -1,10 +1,11 @@
 use crate::{
     dependencies::{load_dependencies, LoadedDependencies},
-    get_version_string, parse_enum_result, EnumerationResult, PicoDriver,
+    get_version_string, parse_enum_result,
+    trampoline::split_closure,
+    EnumerationResult, PicoDriver,
 };
 use c_vec::CVec;
 use lazy_static::lazy_static;
-use libffi::high::ClosureMut8;
 use parking_lot::{Mutex, RwLock};
 use pico_common::{
     ChannelConfig, DownsampleMode, Driver, FromPicoStr, PicoChannel, PicoError, PicoInfo,
@@ -74,6 +75,7 @@ impl PS4000ADriver {
     {
         let dependencies = load_dependencies(&path.as_ref());
         let bindings = unsafe { PS4000ALoader::new(path)? };
+        unsafe { bindings.ps4000aApplyFix(0x1ced9168, 0x11e6) };
         Ok(PS4000ADriver {
             bindings,
             _dependencies: dependencies,
@@ -328,18 +330,16 @@ impl PicoDriver for PS4000ADriver {
         _channels: &[PicoChannel],
         mut callback: Box<dyn FnMut(usize, usize) + 'a>,
     ) -> PicoResult<()> {
-        let mut simplify_args = |_, sample_count, start_index, _, _, _, _, _| {
-            callback(start_index as usize, sample_count as usize);
-        };
-
-        let closure_mut = ClosureMut8::new(&mut simplify_args);
+        let mut simplify_args =
+            |_: i16, sample_count: i32, start_index: u32, _: i16, _: u32, _: i16, _: i16| {
+                callback(start_index as usize, sample_count as usize);
+            };
 
         let status = PicoStatus::from(unsafe {
-            self.bindings.ps4000aGetStreamingLatestValues(
-                handle,
-                Some(*closure_mut.code_ptr()),
-                std::ptr::null_mut(),
-            )
+            let (state, callback) = split_closure(&mut simplify_args);
+
+            self.bindings
+                .ps4000aGetStreamingLatestValues(handle, Some(callback), state)
         });
 
         match status {

--- a/driver/src/ps5000a.rs
+++ b/driver/src/ps5000a.rs
@@ -30,6 +30,7 @@ impl PS5000ADriver {
     {
         let dependencies = load_dependencies(&path.as_ref());
         let bindings = unsafe { PS5000ALoader::new(path)? };
+        // Disables the splash screen on Windows
         unsafe { bindings.ps5000aApplyFix(0x1ced9168, 0x11e6) };
         Ok(PS5000ADriver {
             bindings,

--- a/driver/src/ps6000.rs
+++ b/driver/src/ps6000.rs
@@ -1,8 +1,9 @@
 use crate::{
     dependencies::{load_dependencies, LoadedDependencies},
-    get_version_string, parse_enum_result, EnumerationResult, PicoDriver,
+    get_version_string, parse_enum_result,
+    trampoline::split_closure,
+    EnumerationResult, PicoDriver,
 };
-use libffi::high::ClosureMut8;
 use parking_lot::RwLock;
 use pico_common::{
     ChannelConfig, DownsampleMode, Driver, FromPicoStr, PicoChannel, PicoError, PicoInfo,
@@ -29,6 +30,7 @@ impl PS6000Driver {
     {
         let dependencies = load_dependencies(&path.as_ref());
         let bindings = unsafe { PS6000Loader::new(path)? };
+        unsafe { bindings.ps6000ApplyFix(0x1ced9168, 0x11e6) };
         Ok(PS6000Driver {
             bindings,
             _dependencies: dependencies,
@@ -229,18 +231,16 @@ impl PicoDriver for PS6000Driver {
         _channels: &[PicoChannel],
         mut callback: Box<dyn FnMut(usize, usize) + 'a>,
     ) -> PicoResult<()> {
-        let mut simplify_args = |_, sample_count, start_index, _, _, _, _, _| {
-            callback(start_index as usize, sample_count as usize);
-        };
-
-        let closure = ClosureMut8::new(&mut simplify_args);
+        let mut simplify_args =
+            |_: i16, sample_count: u32, start_index: u32, _: i16, _: u32, _: i16, _: i16| {
+                callback(start_index as usize, sample_count as usize);
+            };
 
         let status = PicoStatus::from(unsafe {
-            self.bindings.ps6000GetStreamingLatestValues(
-                handle,
-                Some(*closure.code_ptr()),
-                std::ptr::null_mut(),
-            )
+            let (state, callback) = split_closure(&mut simplify_args);
+
+            self.bindings
+                .ps6000GetStreamingLatestValues(handle, Some(callback), state)
         });
 
         match status {

--- a/driver/src/ps6000.rs
+++ b/driver/src/ps6000.rs
@@ -30,6 +30,7 @@ impl PS6000Driver {
     {
         let dependencies = load_dependencies(&path.as_ref());
         let bindings = unsafe { PS6000Loader::new(path)? };
+        // Disables the splash screen on Windows
         unsafe { bindings.ps6000ApplyFix(0x1ced9168, 0x11e6) };
         Ok(PS6000Driver {
             bindings,

--- a/driver/src/ps6000a.rs
+++ b/driver/src/ps6000a.rs
@@ -32,6 +32,8 @@ impl PS6000ADriver {
     {
         let dependencies = load_dependencies(&path.as_ref());
         let bindings = unsafe { PS6000ALoader::new(path)? };
+        // Disables the splash screen on Windows
+        unsafe { bindings.ps6000aApplyFix(0x1ced9168, 0x11e6) };
         Ok(PS6000ADriver {
             bindings,
             _dependencies: dependencies,

--- a/driver/src/trampoline.rs
+++ b/driver/src/trampoline.rs
@@ -1,0 +1,62 @@
+use std::ffi::c_void;
+
+pub unsafe fn split_closure<C, Args, Ret>(closure: &mut C) -> (*mut c_void, C::Trampoline)
+where
+    C: Split<Args, Ret>,
+{
+    (closure as *mut C as *mut c_void, C::trampoline())
+}
+
+pub trait Split<Args, Ret> {
+    type Trampoline;
+
+    fn trampoline() -> Self::Trampoline;
+}
+
+macro_rules! impl_split {
+    ($( $outer:ident ),* ; $( $inner:ident ),*) => {
+        impl<Func, Ret, $($outer),*> Split<($( $outer, )*), Ret> for Func
+        where
+            Func: FnMut($($outer),*) -> Ret,
+        {
+            type Trampoline = unsafe extern "C" fn($($outer,)* *mut c_void) -> Ret;
+
+            fn trampoline() -> Self::Trampoline {
+                // declare a trampoline function which will turn our pointer
+                // back into an `F` and invoke it
+
+                // Note: we're deliberately using `$inner` to generate an ident
+                // for the argument
+                #[allow(non_snake_case)]
+                unsafe extern "C" fn trampoline<T, Ret_, $( $inner ),*>($($inner: $inner,)* ptr: *mut c_void) -> Ret_
+                where
+                    T: FnMut($($inner),*) -> Ret_,
+                {
+                    debug_assert!(!ptr.is_null());
+
+                    let callback: &mut T = &mut *(ptr as *mut T);
+
+                    callback($($inner),*)
+                }
+
+                trampoline::<Func, Ret, $($outer,)*>
+            }
+        }
+    };
+}
+
+impl_split!(;);
+impl_split!(A; A);
+impl_split!(A, B; A, B);
+impl_split!(A, B, C; A, B, C);
+impl_split!(A, B, C, D; A, B, C, D);
+impl_split!(A, B, C, D, E; A, B, C, D, E);
+impl_split!(A, B, C, D, E, F; A, B, C, D, E, F);
+impl_split!(A, B, C, D, E, F, G; A, B, C, D, E, F, G);
+impl_split!(A, B, C, D, E, F, G, H; A, B, C, D, E, F, G, H);
+impl_split!(A, B, C, D, E, F, G, H, I; A, B, C, D, E, F, G, H, I);
+impl_split!(A, B, C, D, E, F, G, H, I, K; A, B, C, D, E, F, G, H, I, K);
+impl_split!(A, B, C, D, E, F, G, H, I, K, L; A, B, C, D, E, F, G, H, I, K, L);
+impl_split!(A, B, C, D, E, F, G, H, I, K, L, M; A, B, C, D, E, F, G, H, I, K, L, M);
+impl_split!(A, B, C, D, E, F, G, H, I, K, L, M, N; A, B, C, D, E, F, G, H, I, K, L, M, N);
+impl_split!(A, B, C, D, E, F, G, H, I, K, L, M, N, O; A, B, C, D, E, F, G, H, I, K, L, M, N, O);

--- a/enumeration/Cargo.toml
+++ b/enumeration/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "pico-enumeration"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.0"
+version = "0.3.1"
 
 [lib]
 crate-type = ["lib"]
@@ -15,9 +15,9 @@ path = "src/lib.rs"
 
 [dependencies]
 parking_lot = "0.11"
-pico-common = {path = "../common", version = "0.3.0"}
-pico-device = {path = "../device", version = "0.3.0"}
-pico-driver = {path = "../driver", version = "0.3.0"}
+pico-common = {path = "../common", version = "0.3.1"}
+pico-device = {path = "../device", version = "0.3.1"}
+pico-driver = {path = "../driver", version = "0.3.1"}
 rayon = "1.3"
 serde = {version = "1.0", features = ["derive"], optional = true}
 thiserror = "1.0"

--- a/enumeration/src/lib.rs
+++ b/enumeration/src/lib.rs
@@ -142,9 +142,9 @@ impl DeviceEnumerator {
     /// Enumerates required drivers and returns a flattened list of results
     pub fn enumerate(&self) -> Vec<Result<EnumeratedDevice, EnumerationError>> {
         DeviceEnumerator::enumerate_raw()
-            .par_iter()
+            .into_par_iter()
             .flat_map(|(driver_type, device_count)| {
-                self.enumerate_driver(*driver_type, Some(*device_count))
+                self.enumerate_driver(driver_type, Some(device_count))
             })
             .collect()
     }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "pico-sdk"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.0"
+version = "0.3.1"
 
 [lib]
 crate-type = ["lib"]
@@ -17,13 +17,13 @@ path = "src/lib.rs"
 serde = ["pico-common/serde", "pico-device/serde", "pico-enumeration/serde", "pico-streaming/serde"]
 
 [dependencies]
-pico-common = {path = "../common", version = "0.3.0"}
-pico-device = {path = "../device", version = "0.3.0"}
-pico-download = {path = "../download", version = "0.3.0"}
-pico-driver = {path = "../driver", version = "0.3.0"}
-pico-enumeration = {path = "../enumeration", version = "0.3.0"}
-pico-streaming = {path = "../streaming", version = "0.3.0"}
-pico-sys-dynamic = {path = "../sys", version = "0.3.0"}
+pico-common = {path = "../common", version = "0.3.1"}
+pico-device = {path = "../device", version = "0.3.1"}
+pico-download = {path = "../download", version = "0.3.1"}
+pico-driver = {path = "../driver", version = "0.3.1"}
+pico-enumeration = {path = "../enumeration", version = "0.3.1"}
+pico-streaming = {path = "../streaming", version = "0.3.1"}
+pico-sys-dynamic = {path = "../sys", version = "0.3.1"}
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -27,13 +27,9 @@ numerous Pico drivers.
     Implements continuous gap-less streaming on top of `PicoDevice`.
 
 ## Prerequisites
-`pico-driver` uses a C library called `libffi` to call into older Pico
-drivers that don't allow us to pass context through callbacks. To build this
-you will need a working C compiler and on Unix based platforms you'll also
-[require `automake`, and
-`autoconf`](https://github.com/meatysolutions/pico-sdk/issues/5).
-
-On linux `pico-enumeration` [requires `libudev-dev`](https://github.com/meatysolutions/pico-sdk/blob/700ab24efe81063316baffff638988cf626c6ffe/.github/workflows/build-and-publish.yml#L32).
+On linux `pico-enumeration` [requires
+`libudev-dev`](https://github.com/meatysolutions/pico-sdk/blob/700ab24efe81063316baffff638988cf626c6ffe/.github/workflows/build-and-publish.yml#L32)
+to be installed.
 
 ## Tests
 Some tests open and stream from devices and these fail if devices are not available, for example when run in CI.

--- a/sdk/examples/streaming_cli.rs
+++ b/sdk/examples/streaming_cli.rs
@@ -60,11 +60,14 @@ impl RateCalc {
             .unwrap_or(0)
     }
 }
+
 fn main() -> Result<()> {
-    // tracing_subscriber::fmt()
-    //     .with_max_level(tracing::Level::TRACE)
-    //     .with_span_events(tracing_subscriber::fmt::format::FmtSpan::ACTIVE)
-    //     .init();
+    if std::env::args().any(|a| a.contains("--trace")) {
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::TRACE)
+            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::ACTIVE)
+            .init();
+    }
 
     let enumerator = DeviceEnumerator::with_resolution(cache_resolution());
     let device = select_device(&enumerator)?;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -27,13 +27,9 @@
 //!     Implements continuous gap-less streaming on top of `PicoDevice`.
 //!
 //! # Prerequisites
-//! `pico-driver` uses a C library called `libffi` to call into older Pico
-//! drivers that don't allow us to pass context through callbacks. To build this
-//! you will need a working C compiler and on Unix based platforms you'll also
-//! [require `automake`, and
-//! `autoconf`](https://github.com/meatysolutions/pico-sdk/issues/5).
-//!
-//! On linux `pico-enumeration` [requires `libudev-dev`](https://github.com/meatysolutions/pico-sdk/blob/700ab24efe81063316baffff638988cf626c6ffe/.github/workflows/build-and-publish.yml#L32).
+//! On linux `pico-enumeration` [requires
+//! `libudev-dev`](https://github.com/meatysolutions/pico-sdk/blob/700ab24efe81063316baffff638988cf626c6ffe/.github/workflows/build-and-publish.yml#L32)
+//! to be installed.
 //!
 //! # Tests
 //! Some tests open and stream from devices and these fail if devices are not available, for example when run in CI.

--- a/streaming/Cargo.toml
+++ b/streaming/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "pico-streaming"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.0"
+version = "0.3.1"
 
 [lib]
 crate-type = ["lib"]
@@ -16,9 +16,9 @@ path = "src/lib.rs"
 [dependencies]
 crossbeam = "0.8"
 parking_lot = {version = "0.11", features = ["serde"]}
-pico-common = {path = "../common", version = "0.3.0"}
-pico-device = {path = "../device", version = "0.3.0"}
-pico-driver = {path = "../driver", version = "0.3.0"}
+pico-common = {path = "../common", version = "0.3.1"}
+pico-device = {path = "../device", version = "0.3.1"}
+pico-driver = {path = "../driver", version = "0.3.1"}
 serde = {version = "1.0", features = ["derive", "rc"], optional = true}
 tracing = {version = "0.1", features = ["attributes"]}
 

--- a/streaming/src/lib.rs
+++ b/streaming/src/lib.rs
@@ -438,7 +438,7 @@ impl PicoStreamingDevice {
         buffers: BufferMap,
         actual_sample_rate: u32,
     ) -> (State, Duration) {
-        let closure = |start_index, sample_count| {
+        let callback = |start_index, sample_count| {
             let channels = self.enabled_channels.read();
 
             let channels = channels
@@ -472,7 +472,7 @@ impl PicoStreamingDevice {
         if let Err(error) =
             self.device
                 .driver
-                .get_latest_streaming_values(handle, &channels, Box::new(closure))
+                .get_latest_streaming_values(handle, &channels, Box::new(callback))
         {
             if error.status == PicoStatus::WAITING_FOR_DATA_BUFFERS {
                 for (channel, buffer) in &buffers {

--- a/streaming/src/lib.rs
+++ b/streaming/src/lib.rs
@@ -68,7 +68,7 @@ mod events;
 enum Target {
     Closed,
     Open,
-    Streaming { requested_samples_rate: u32 },
+    Streaming { requested_sample_rate: u32 },
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
@@ -246,15 +246,15 @@ impl PicoStreamingDevice {
 
     /// Start streaming
     #[tracing::instrument(level = "info")]
-    pub fn start(&self, requested_samples_rate: u32) -> PicoResult<u32> {
+    pub fn start(&self, requested_sample_rate: u32) -> PicoResult<u32> {
         // Set the target state
         {
             self.target_state.set(Target::Streaming {
-                requested_samples_rate,
+                requested_sample_rate,
             });
         }
 
-        // Drive the state until we get the correct state or error
+        // Drive the state until we get the correct state or an error we can return
         let mut count = 0;
         loop {
             self.run_state()?;
@@ -339,8 +339,8 @@ impl PicoStreamingDevice {
                 }
                 Target::Open => self.ping(handle),
                 Target::Streaming {
-                    requested_samples_rate,
-                } => self.configure_and_start(handle, requested_samples_rate)?,
+                    requested_sample_rate,
+                } => self.configure_and_start(handle, requested_sample_rate)?,
             },
             State::Streaming {
                 handle,

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "pico-sys-dynamic"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.0"
+version = "0.3.1"
 
 [lib]
 crate-type = ["lib"]

--- a/sys/src/ps2000.rs
+++ b/sys/src/ps2000.rs
@@ -196,6 +196,7 @@ pub type PS2000_PWQ_CONDITIONS = tPS2000PwqConditions;
 extern crate libloading;
 pub struct PS2000Loader {
     __library: ::libloading::Library,
+    pub ps2000_apply_fix: Result<unsafe extern "C" fn(u32, u16), ::libloading::Error>,
     pub ps2000_open_unit: Result<unsafe extern "C" fn() -> i16, ::libloading::Error>,
     pub ps2000_get_unit_info: Result<
         unsafe extern "C" fn(handle: i16, string: *mut i8, string_length: i16, line: i16) -> i16,
@@ -441,6 +442,7 @@ impl PS2000Loader {
         P: AsRef<::std::ffi::OsStr>,
     {
         let __library = ::libloading::Library::new(path)?;
+        let ps2000_apply_fix = __library.get(b"ps2000_apply_fix\0").map(|sym| *sym);
         let ps2000_open_unit = __library.get(b"ps2000_open_unit\0").map(|sym| *sym);
         let ps2000_get_unit_info = __library.get(b"ps2000_get_unit_info\0").map(|sym| *sym);
         let ps2000_flash_led = __library.get(b"ps2000_flash_led\0").map(|sym| *sym);
@@ -500,6 +502,7 @@ impl PS2000Loader {
         let ps2000PingUnit = __library.get(b"ps2000PingUnit\0").map(|sym| *sym);
         Ok(PS2000Loader {
             __library,
+            ps2000_apply_fix,
             ps2000_open_unit,
             ps2000_get_unit_info,
             ps2000_flash_led,
@@ -534,6 +537,13 @@ impl PS2000Loader {
             ps2000SetAdvTriggerDelay,
             ps2000PingUnit,
         })
+    }
+    pub unsafe fn ps2000_apply_fix(&self, a: u32, b: u16) {
+        let sym = self
+            .ps2000_apply_fix
+            .as_ref()
+            .expect("Expected function, got error.");
+        (sym)(a, b)
     }
     pub unsafe fn ps2000_open_unit(&self) -> i16 {
         let sym = self

--- a/sys/src/ps2000a.rs
+++ b/sys/src/ps2000a.rs
@@ -1214,6 +1214,7 @@ pub struct __va_list_tag {
 extern crate libloading;
 pub struct PS2000ALoader {
     __library: ::libloading::Library,
+    pub ps2000aApplyFix: Result<unsafe extern "C" fn(u32, u16), ::libloading::Error>,
     pub ps2000aOpenUnit: Result<
         unsafe extern "C" fn(handle: *mut i16, serial: *mut i8) -> PICO_STATUS,
         ::libloading::Error,
@@ -1783,6 +1784,7 @@ impl PS2000ALoader {
         P: AsRef<::std::ffi::OsStr>,
     {
         let __library = ::libloading::Library::new(path)?;
+        let ps2000aApplyFix = __library.get(b"ps2000aApplyFix\0").map(|sym| *sym);
         let ps2000aOpenUnit = __library.get(b"ps2000aOpenUnit\0").map(|sym| *sym);
         let ps2000aOpenUnitAsync = __library.get(b"ps2000aOpenUnitAsync\0").map(|sym| *sym);
         let ps2000aOpenUnitProgress = __library.get(b"ps2000aOpenUnitProgress\0").map(|sym| *sym);
@@ -1908,6 +1910,7 @@ impl PS2000ALoader {
         let ps2000aGetScalingValues = __library.get(b"ps2000aGetScalingValues\0").map(|sym| *sym);
         Ok(PS2000ALoader {
             __library,
+            ps2000aApplyFix,
             ps2000aOpenUnit,
             ps2000aOpenUnitAsync,
             ps2000aOpenUnitProgress,
@@ -1974,6 +1977,13 @@ impl PS2000ALoader {
             ps2000aSetOutputEdgeDetect,
             ps2000aGetScalingValues,
         })
+    }
+    pub unsafe fn ps2000aApplyFix(&self, a: u32, b: u16) {
+        let sym = self
+            .ps2000aApplyFix
+            .as_ref()
+            .expect("Expected function, got error.");
+        (sym)(a, b)
     }
     pub unsafe fn ps2000aOpenUnit(&self, handle: *mut i16, serial: *mut i8) -> PICO_STATUS {
         let sym = self

--- a/sys/src/ps3000.rs
+++ b/sys/src/ps3000.rs
@@ -199,6 +199,7 @@ pub struct __va_list_tag {
 extern crate libloading;
 pub struct PS3000Loader {
     __library: ::libloading::Library,
+    pub ps3000_apply_fix: Result<unsafe extern "C" fn(u32, u16), ::libloading::Error>,
     pub ps3000_open_unit: Result<unsafe extern "C" fn() -> i16, ::libloading::Error>,
     pub ps3000_get_unit_info: Result<
         unsafe extern "C" fn(handle: i16, string: *mut i8, string_length: i16, line: i16) -> i16,
@@ -438,6 +439,7 @@ impl PS3000Loader {
         P: AsRef<::std::ffi::OsStr>,
     {
         let __library = ::libloading::Library::new(path)?;
+        let ps3000_apply_fix = __library.get(b"ps3000_apply_fix\0").map(|sym| *sym);
         let ps3000_open_unit = __library.get(b"ps3000_open_unit\0").map(|sym| *sym);
         let ps3000_get_unit_info = __library.get(b"ps3000_get_unit_info\0").map(|sym| *sym);
         let ps3000_flash_led = __library.get(b"ps3000_flash_led\0").map(|sym| *sym);
@@ -498,6 +500,7 @@ impl PS3000Loader {
         let ps3000PingUnit = __library.get(b"ps3000PingUnit\0").map(|sym| *sym);
         Ok(PS3000Loader {
             __library,
+            ps3000_apply_fix,
             ps3000_open_unit,
             ps3000_get_unit_info,
             ps3000_flash_led,
@@ -531,6 +534,13 @@ impl PS3000Loader {
             ps3000SetAdvTriggerDelay,
             ps3000PingUnit,
         })
+    }
+    pub unsafe fn ps3000_apply_fix(&self, a: u32, b: u16) {
+        let sym = self
+            .ps3000_apply_fix
+            .as_ref()
+            .expect("Expected function, got error.");
+        (sym)(a, b)
     }
     pub unsafe fn ps3000_open_unit(&self) -> i16 {
         let sym = self

--- a/sys/src/ps5000.rs
+++ b/sys/src/ps5000.rs
@@ -322,6 +322,7 @@ pub type ps5000DataReady = ::std::option::Option<
 extern crate libloading;
 pub struct PS5000Loader {
     __library: ::libloading::Library,
+    pub ps5000ApplyFix: Result<unsafe extern "C" fn(u32, u16), ::libloading::Error>,
     pub ps5000OpenUnit:
         Result<unsafe extern "C" fn(handle: *mut i16) -> PICO_STATUS, ::libloading::Error>,
     pub ps5000OpenUnitAsync:
@@ -732,6 +733,7 @@ impl PS5000Loader {
         P: AsRef<::std::ffi::OsStr>,
     {
         let __library = ::libloading::Library::new(path)?;
+        let ps5000ApplyFix = __library.get(b"ps5000ApplyFix\0").map(|sym| *sym);
         let ps5000OpenUnit = __library.get(b"ps5000OpenUnit\0").map(|sym| *sym);
         let ps5000OpenUnitAsync = __library.get(b"ps5000OpenUnitAsync\0").map(|sym| *sym);
         let ps5000OpenUnitProgress = __library.get(b"ps5000OpenUnitProgress\0").map(|sym| *sym);
@@ -810,6 +812,7 @@ impl PS5000Loader {
         let ps5000SetNoOfCaptures = __library.get(b"ps5000SetNoOfCaptures\0").map(|sym| *sym);
         Ok(PS5000Loader {
             __library,
+            ps5000ApplyFix,
             ps5000OpenUnit,
             ps5000OpenUnitAsync,
             ps5000OpenUnitProgress,
@@ -857,6 +860,13 @@ impl PS5000Loader {
             ps5000PingUnit,
             ps5000SetNoOfCaptures,
         })
+    }
+    pub unsafe fn ps5000ApplyFix(&self, a: u32, b: u16) {
+        let sym = self
+            .ps5000ApplyFix
+            .as_ref()
+            .expect("Expected function, got error.");
+        (sym)(a, b)
     }
     pub unsafe fn ps5000OpenUnit(&self, handle: *mut i16) -> PICO_STATUS {
         let sym = self

--- a/sys/src/ps6000.rs
+++ b/sys/src/ps6000.rs
@@ -346,7 +346,7 @@ pub const enPS6000Temperatures_PS6000_INTERNAL_TEMPERATURE: enPS6000Temperatures
 pub type enPS6000Temperatures = ::std::os::raw::c_uint;
 pub use self::enPS6000Temperatures as PS6000_TEMPERATURES;
 pub type ps6000BlockReady = ::std::option::Option<
-    extern "C" fn(handle: i16, status: PICO_STATUS, pParameter: *mut ::std::os::raw::c_void),
+    unsafe extern "C" fn(handle: i16, status: PICO_STATUS, pParameter: *mut ::std::os::raw::c_void),
 >;
 pub type ps6000StreamingReady = ::std::option::Option<
     unsafe extern "C" fn(

--- a/sys/src/ps6000a.rs
+++ b/sys/src/ps6000a.rs
@@ -793,6 +793,7 @@ pub type ps6000aProbeInteractions = ::std::option::Option<
 extern crate libloading;
 pub struct PS6000ALoader {
     __library: ::libloading::Library,
+    pub ps6000aApplyFix: Result<unsafe extern "C" fn(u32, u16), ::libloading::Error>,
     pub ps6000aOpenUnit: Result<
         unsafe extern "C" fn(
             handle: *mut i16,
@@ -1395,6 +1396,7 @@ impl PS6000ALoader {
         P: AsRef<::std::ffi::OsStr>,
     {
         let __library = ::libloading::Library::new(path)?;
+        let ps6000aApplyFix = __library.get(b"ps6000aApplyFix\0").map(|sym| *sym);
         let ps6000aOpenUnit = __library.get(b"ps6000aOpenUnit\0").map(|sym| *sym);
         let ps6000aOpenUnitAsync = __library.get(b"ps6000aOpenUnitAsync\0").map(|sym| *sym);
         let ps6000aOpenUnitProgress = __library.get(b"ps6000aOpenUnitProgress\0").map(|sym| *sym);
@@ -1545,6 +1547,7 @@ impl PS6000ALoader {
             .map(|sym| *sym);
         Ok(PS6000ALoader {
             __library,
+            ps6000aApplyFix,
             ps6000aOpenUnit,
             ps6000aOpenUnitAsync,
             ps6000aOpenUnitProgress,
@@ -1624,6 +1627,13 @@ impl PS6000ALoader {
             ps6000aResetChannelsAndReportAllChannelsOvervoltageTripStatus,
             ps6000aReportAllChannelsOvervoltageTripStatus,
         })
+    }
+    pub unsafe fn ps6000aApplyFix(&self, a: u32, b: u16) {
+        let sym = self
+            .ps6000aApplyFix
+            .as_ref()
+            .expect("Expected function, got error.");
+        (sym)(a, b)
     }
     pub unsafe fn ps6000aOpenUnit(
         &self,


### PR DESCRIPTION
- Remove libffi dependency
- Use `*ApplyFix` calls to remove driver splash screen on Windows