### PR TITLE
feat: A few improvements

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 authors = ["Tim Fish <tim@timfish.uk>"]
 description = "Unofficial Rust bindings and wrappers for Pico Technology oscilloscope drivers"
-edition = "2018"
+edition = "2021"
 keywords = ["Oscilloscope", "Streaming", "PicoScope", "Pico-Technology"]
 license = "MIT"
 name = "pico-common"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.1"
+version = "0.4.0"
 
 [lib]
 crate-type = ["lib"]

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -3,7 +3,7 @@ use num_derive::*;
 use std::convert::From;
 
 /// Pico time units
-#[derive(Debug, Clone, Copy, FromPrimitive, ToPrimitive, PartialEq)]
+#[derive(Debug, Clone, Copy, FromPrimitive, ToPrimitive, PartialEq, Eq)]
 pub enum TimeUnits {
     FS = 0,
     PS = 1,

--- a/common/src/driver.rs
+++ b/common/src/driver.rs
@@ -28,7 +28,7 @@ impl FromStr for Driver {
     type Err = ParseError;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let input = input.to_uppercase().replace("PS", "").replace(" ", "");
+        let input = input.to_uppercase().replace("PS", "").replace(' ', "");
 
         match &input[..] {
             "2000" => Ok(Driver::PS2000),

--- a/common/src/enums.rs
+++ b/common/src/enums.rs
@@ -2,7 +2,7 @@ use num_derive::*;
 use std::{convert::From, fmt, str::FromStr};
 
 /// Error when attempting to parse enums from strings
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ParseError;
 
 #[derive(Debug, Clone, Copy, FromPrimitive, ToPrimitive, Ord, PartialOrd, Hash, PartialEq, Eq)]
@@ -23,7 +23,7 @@ impl FromStr for PicoChannel {
     type Err = ParseError;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let input = input.replace(" ", "").to_uppercase();
+        let input = input.replace(' ', "").to_uppercase();
 
         match &input[..] {
             "A" => Ok(PicoChannel::A),
@@ -99,7 +99,7 @@ impl FromStr for PicoCoupling {
     type Err = ParseError;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let input = input.replace(" ", "").to_uppercase();
+        let input = input.replace(' ', "").to_uppercase();
 
         match &input[..] {
             "AC" => Ok(PicoCoupling::AC),

--- a/common/src/range.rs
+++ b/common/src/range.rs
@@ -5,7 +5,7 @@ use std::fmt;
 /// Pico channel ranges
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, FromPrimitive, ToPrimitive, PartialEq, IntoEnumIterator)]
+#[derive(Debug, Clone, Copy, FromPrimitive, ToPrimitive, PartialEq, Eq, IntoEnumIterator)]
 pub enum PicoRange {
     X1_PROBE_10MV = 0,
     X1_PROBE_20MV = 1,
@@ -138,14 +138,14 @@ pub enum PicoRange {
 
 impl PicoRange {
     pub fn parse(input: &str, valid_ranges: Option<&[Self]>) -> Option<Self> {
-        let input = input.replace(" ", "").replace("±", "").to_uppercase();
+        let input = input.replace([' ', '±'], "").to_uppercase();
         let all_ranges = PicoRange::into_enum_iter().collect::<Vec<Self>>();
         let valid_ranges = valid_ranges.unwrap_or(&all_ranges);
 
         for range in valid_ranges {
             let to_cmp = format!("{}", range)
-                .replace(" ", "")
-                .replace("±", "")
+                .replace(' ', "")
+                .replace('±', "")
                 .to_uppercase();
 
             if input == to_cmp {

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 authors = ["Tim Fish <tim@timfish.uk>"]
 description = "Unofficial Rust bindings and wrappers for Pico Technology oscilloscope drivers"
-edition = "2018"
+edition = "2021"
 keywords = ["Oscilloscope", "Streaming", "PicoScope", "Pico-Technology"]
 license = "MIT"
 name = "pico-device"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.1"
+version = "0.4.0"
 
 [lib]
 crate-type = ["lib"]
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 
 [dependencies]
 parking_lot = "0.11"
-pico-common = {path = "../common", version = "0.3.1"}
-pico-driver = {path = "../driver", version = "0.3.1"}
+pico-common = {path = "../common", version = "0.4.0"}
+pico-driver = {path = "../driver", version = "0.4.0"}
 serde = {version = "1.0", features = ["derive", "rc"], optional = true}
 tracing = {version = "0.1", features = ["attributes"]}

--- a/device/README.md
+++ b/device/README.md
@@ -11,11 +11,11 @@ automatically detected and then it is closed.
 ## Example
 ```rust
 use pico_common::Driver;
-use pico_driver::LoadDriverExt;
+use pico_driver::LibraryResolution;
 use pico_device::PicoDevice;
 
 // Load the required driver
-let driver = Driver::PS2000.try_load()?;
+let driver = LibraryResolution::Default.try_load(Driver::PS2000)?;
 
 // Try and open the first available ps2000 device
 let device1 = PicoDevice::try_open(&driver, None)?;

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 authors = ["Tim Fish <tim@timfish.uk>"]
 description = "Unofficial Rust bindings and wrappers for Pico Technology oscilloscope drivers"
-edition = "2018"
+edition = "2021"
 keywords = ["Oscilloscope", "Streaming", "PicoScope", "Pico-Technology"]
 license = "MIT"
 name = "pico-download"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.1"
+version = "0.4.0"
 
 [lib]
 crate-type = ["lib"]
@@ -16,8 +16,8 @@ path = "src/lib.rs"
 [dependencies]
 directories = "3.0"
 http_req = "^0.7"
-pico-common = {path = "../common", version = "0.3.1"}
-pico-driver = {path = "../driver", version = "0.3.1"}
+pico-common = {path = "../common", version = "0.4.0"}
+pico-driver = {path = "../driver", version = "0.4.0"}
 ring = "0.16"
 thiserror = "^1.0"
 

--- a/download/examples/generate-hashes.rs
+++ b/download/examples/generate-hashes.rs
@@ -74,5 +74,9 @@ fn main() {
         })
     });
 
+    // Pico do not yet distribute drivers for macOS aarch64 so throw an error at compile time
+    println!("    #[cfg(all(target_os = \"macos\", target_arch = \"aarch64\"))]");
+    println!("    compile_error!(\"Pico do not yet distribute drivers for macOS aarch64. You'll need to target x86_64 for now!\");");
+
     println!("}}");
 }

--- a/download/src/hashes.rs
+++ b/download/src/hashes.rs
@@ -1,5 +1,4 @@
 #![allow(unreachable_patterns)]
-
 use pico_common::Driver;
 /// This file is auto-generated from the generate-hashes example
 pub fn get_expected_driver_hash(driver: Driver) -> &'static str {
@@ -65,7 +64,10 @@ pub fn get_expected_driver_hash(driver: Driver) -> &'static str {
         Driver::PS4000A => "SHA256:cc94889fe114ce1d67fb4262e9aab9aee14d3013b748152949b279f23f6d7cc9",
         Driver::PS5000A => "SHA256:af58a1c0bfedea56d5ce9b2c53d69ec1e41f6098d1d03ce9b14579277893327f",
         Driver::PS6000 => "SHA256:32ca7e7eebac2c1772423d3b5b74eaac5559bac8b33454f1757d3cfd4b788a14",
+        Driver::PS6000A => "SHA256:2ebc87f9b3c638bce175f5cb69dabc9da50a3eca0ec4e44143e3ab9adfe8f119",
         Driver::PicoIPP => "SHA256:cde63e4aaafd567acc6c991c403a600fd0b8e4274c85ccad4eed04952b51daad",
         _ => ""
     }
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    compile_error!("Pico do not yet distribute drivers for macOS aarch64. You'll need to target x86_64 for now!");
 }

--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -30,7 +30,7 @@ use hashes::get_expected_driver_hash;
 use http_req::request;
 use paths::get_cache_dir;
 use pico_common::Driver;
-use pico_driver::Resolution;
+use pico_driver::LibraryResolution;
 use ring::digest::{Context, Digest, SHA256};
 use std::{fs, io::Read, path::Path};
 use thiserror::Error;
@@ -54,8 +54,8 @@ pub enum DriverDownloadError {
 }
 
 /// Gets a `Resolution` that points to the download cache location
-pub fn cache_resolution() -> Resolution {
-    Resolution::Custom(get_cache_dir())
+pub fn cache_resolution() -> LibraryResolution {
+    LibraryResolution::Custom(get_cache_dir())
 }
 
 /// Downloads the requested drivers and any dependencies to the supplied path.
@@ -70,7 +70,7 @@ pub fn download_drivers<P: AsRef<Path>>(
     fs::create_dir_all(&driver_dir)?;
 
     for driver in required_files {
-        let file_path = driver_dir.join(&driver.get_binary_name());
+        let file_path = driver_dir.join(driver.get_binary_name());
 
         if file_path.exists() {
             match driver {

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 authors = ["Tim Fish <tim@timfish.uk>"]
 description = "Unofficial Rust bindings and wrappers for Pico Technology oscilloscope drivers"
-edition = "2018"
+edition = "2021"
 keywords = ["Oscilloscope", "Streaming", "PicoScope", "Pico-Technology"]
 license = "MIT"
 name = "pico-driver"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.1"
+version = "0.4.0"
 
 [lib]
 crate-type = ["lib"]
@@ -18,8 +18,8 @@ c_vec = "2.0"
 lazy_static = "1.4"
 libloading = "0.7"
 parking_lot = "0.11"
-pico-common = {path = "../common", version = "0.3.1"}
-pico-sys-dynamic = {path = "../sys", version = "0.3.1"}
+pico-common = {path = "../common", version = "0.4.0"}
+pico-sys-dynamic = {path = "../sys", version = "0.4.0"}
 thiserror = "^1.0"
 tracing = {version = "0.1", features = ["attributes"]}
 version-compare = "0.0.11"

--- a/driver/README.md
+++ b/driver/README.md
@@ -13,19 +13,18 @@ either a few function arguments or a vastly differing API.
 `PS4000ADriver`, `PS5000ADriver`, `PS6000Driver` and `PS6000ADriver` wrap
 their corresponding loaders and expose a safe, common API by implementing
 the `PicoDriver` trait. These can be constructed with a `Resolution` which tells the wrapper where
-to resolve the dynamic library from. The `LoadDriverExt` trait supplies a shortcut to load a driver
-directly from the `Driver` enum via `try_load` and `try_load_with_resolution`.
+to resolve the dynamic library from.
 
 ## Examples
 Using the raw safe bindings to open and configure the first available device:
 ```rust
 use pico_common::{ChannelConfig, Driver, PicoChannel, PicoCoupling, PicoInfo, PicoRange};
-use pico_driver::{LoadDriverExt, Resolution};
+use pico_driver::LibraryResolution;
 
 // Load the ps2000 driver library with the default resolution
-let driver = Driver::PS2000.try_load()?;
+let driver = LibraryResolution::Default.try_load(Driver::PS2000)?;
 // Load the ps4000a driver library from the applications root directory
-let driver = Driver::PS4000A.try_load_with_resolution(&Resolution::AppRoot)?;
+let driver = LibraryResolution::AppRoot.try_load(Driver::PS4000A)?;
 
 // Open the first device
 let handle = driver.open_unit(None)?;

--- a/driver/src/dependencies.rs
+++ b/driver/src/dependencies.rs
@@ -1,4 +1,4 @@
-use super::Resolution;
+use super::LibraryResolution;
 use lazy_static::lazy_static;
 use libloading::{Error, Library};
 use parking_lot::Mutex;
@@ -14,6 +14,8 @@ type LoadedDependency = (LoadedFn, Library);
 pub type LoadedDependencies = Vec<Arc<LoadedDependency>>;
 
 lazy_static! {
+    // We only hold a weak reference so that they're dropped when there are no
+    // more drivers loaded.
     static ref DEPENDENCY_CACHE: Mutex<HashMap<PathBuf, Weak<LoadedDependency>>> =
         Default::default();
 }
@@ -28,7 +30,7 @@ lazy_static! {
 pub fn load_dependencies<P: AsRef<Path>>(path: P) -> LoadedDependencies {
     let parent = path.as_ref().parent().expect("Driver path has no parent");
     let to_load = Driver::get_dependencies_for_platform();
-    let resolution = Resolution::Custom(parent.to_path_buf());
+    let resolution = LibraryResolution::Custom(parent.to_path_buf());
 
     let mut output = Vec::with_capacity(to_load.len());
 

--- a/driver/src/ps2000a.rs
+++ b/driver/src/ps2000a.rs
@@ -10,7 +10,7 @@ use pico_common::{
     PicoRange, PicoResult, PicoStatus, SampleConfig, ToPicoStr,
 };
 use pico_sys_dynamic::ps2000a::PS2000ALoader;
-use std::{pin::Pin, sync::Arc};
+use std::sync::Arc;
 
 pub struct PS2000ADriver {
     _dependencies: LoadedDependencies,
@@ -28,7 +28,7 @@ impl PS2000ADriver {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
-        let dependencies = load_dependencies(&path.as_ref());
+        let dependencies = load_dependencies(path.as_ref());
         let bindings = unsafe { PS2000ALoader::new(path)? };
         // Disables the splash screen on Windows
         unsafe { bindings.ps2000aApplyFix(0x1ced9168, 0x11e6) };
@@ -206,7 +206,7 @@ impl PicoDriver for PS2000ADriver {
         &self,
         handle: i16,
         channel: PicoChannel,
-        buffer: Arc<RwLock<Pin<Vec<i16>>>>,
+        buffer: Arc<RwLock<Vec<i16>>>,
         buffer_len: usize,
     ) -> PicoResult<()> {
         let mut buffer = buffer.write();
@@ -229,6 +229,7 @@ impl PicoDriver for PS2000ADriver {
         &self,
         handle: i16,
         sample_config: &SampleConfig,
+        _enabled_channels: u8,
     ) -> PicoResult<SampleConfig> {
         let mut sample_interval = sample_config.interval;
 

--- a/driver/src/ps3000a.rs
+++ b/driver/src/ps3000a.rs
@@ -10,7 +10,7 @@ use pico_common::{
     PicoRange, PicoResult, PicoStatus, SampleConfig, ToPicoStr,
 };
 use pico_sys_dynamic::ps3000a::PS3000ALoader;
-use std::{pin::Pin, sync::Arc};
+use std::sync::Arc;
 
 pub struct PS3000ADriver {
     _dependencies: LoadedDependencies,
@@ -28,7 +28,7 @@ impl PS3000ADriver {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
-        let dependencies = load_dependencies(&path.as_ref());
+        let dependencies = load_dependencies(path.as_ref());
         let bindings = unsafe { PS3000ALoader::new(path)? };
         // Disables the splash screen on Windows
         unsafe { bindings.ps3000aApplyFix(0x1ced9168, 0x11e6) };
@@ -217,7 +217,7 @@ impl PicoDriver for PS3000ADriver {
         &self,
         handle: i16,
         channel: PicoChannel,
-        buffer: Arc<RwLock<Pin<Vec<i16>>>>,
+        buffer: Arc<RwLock<Vec<i16>>>,
         buffer_len: usize,
     ) -> PicoResult<()> {
         let mut buffer = buffer.write();
@@ -240,6 +240,7 @@ impl PicoDriver for PS3000ADriver {
         &self,
         handle: i16,
         sample_config: &SampleConfig,
+        _enabled_channels: u8,
     ) -> PicoResult<SampleConfig> {
         let mut sample_interval = vec![sample_config.interval];
 

--- a/driver/src/ps4000.rs
+++ b/driver/src/ps4000.rs
@@ -10,7 +10,7 @@ use pico_common::{
     PicoStatus, SampleConfig, ToPicoStr,
 };
 use pico_sys_dynamic::ps4000::PS4000Loader;
-use std::{pin::Pin, sync::Arc};
+use std::sync::Arc;
 
 pub struct PS4000Driver {
     _dependencies: LoadedDependencies,
@@ -28,7 +28,7 @@ impl PS4000Driver {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
-        let dependencies = load_dependencies(&path.as_ref());
+        let dependencies = load_dependencies(path.as_ref());
         let bindings = unsafe { PS4000Loader::new(path)? };
         // Disables the splash screen on Windows
         unsafe { bindings.ps4000ApplyFix(0x1ced9168, 0x11e6) };
@@ -198,7 +198,7 @@ impl PicoDriver for PS4000Driver {
         &self,
         handle: i16,
         channel: PicoChannel,
-        buffer: Arc<RwLock<Pin<Vec<i16>>>>,
+        buffer: Arc<RwLock<Vec<i16>>>,
         buffer_len: usize,
     ) -> PicoResult<()> {
         let mut buffer = buffer.write();
@@ -219,6 +219,7 @@ impl PicoDriver for PS4000Driver {
         &self,
         handle: i16,
         sample_config: &SampleConfig,
+        _enabled_channels: u8,
     ) -> PicoResult<SampleConfig> {
         let mut sample_interval = vec![sample_config.interval];
 

--- a/driver/src/ps4000a.rs
+++ b/driver/src/ps4000a.rs
@@ -12,7 +12,7 @@ use pico_common::{
     PicoRange, PicoResult, PicoStatus, SampleConfig, ToPicoStr,
 };
 use pico_sys_dynamic::ps4000a::{PS4000ALoader, PS4000A_USER_PROBE_INTERACTIONS};
-use std::{collections::HashMap, matches, pin::Pin, sync::Arc};
+use std::{collections::HashMap, matches, sync::Arc};
 
 type ChannelRangesMap = HashMap<PicoChannel, Vec<PicoRange>>;
 
@@ -73,7 +73,7 @@ impl PS4000ADriver {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
-        let dependencies = load_dependencies(&path.as_ref());
+        let dependencies = load_dependencies(path.as_ref());
         let bindings = unsafe { PS4000ALoader::new(path)? };
         // Disables the splash screen on Windows
         unsafe { bindings.ps4000aApplyFix(0x1ced9168, 0x11e6) };
@@ -279,7 +279,7 @@ impl PicoDriver for PS4000ADriver {
         &self,
         handle: i16,
         channel: PicoChannel,
-        buffer: Arc<RwLock<Pin<Vec<i16>>>>,
+        buffer: Arc<RwLock<Vec<i16>>>,
         buffer_len: usize,
     ) -> PicoResult<()> {
         let mut buffer = buffer.write();
@@ -302,6 +302,7 @@ impl PicoDriver for PS4000ADriver {
         &self,
         handle: i16,
         sample_config: &SampleConfig,
+        _enabled_channels: u8,
     ) -> PicoResult<SampleConfig> {
         let mut sample_interval = sample_config.interval;
 

--- a/driver/src/ps6000.rs
+++ b/driver/src/ps6000.rs
@@ -10,7 +10,7 @@ use pico_common::{
     PicoRange, PicoResult, PicoStatus, SampleConfig, ToPicoStr,
 };
 use pico_sys_dynamic::ps6000::PS6000Loader;
-use std::{pin::Pin, sync::Arc};
+use std::sync::Arc;
 
 pub struct PS6000Driver {
     _dependencies: LoadedDependencies,
@@ -28,7 +28,7 @@ impl PS6000Driver {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
-        let dependencies = load_dependencies(&path.as_ref());
+        let dependencies = load_dependencies(path.as_ref());
         let bindings = unsafe { PS6000Loader::new(path)? };
         // Disables the splash screen on Windows
         unsafe { bindings.ps6000ApplyFix(0x1ced9168, 0x11e6) };
@@ -181,7 +181,7 @@ impl PicoDriver for PS6000Driver {
         &self,
         handle: i16,
         channel: PicoChannel,
-        buffer: Arc<RwLock<Pin<Vec<i16>>>>,
+        buffer: Arc<RwLock<Vec<i16>>>,
         buffer_len: usize,
     ) -> PicoResult<()> {
         let mut buffer = buffer.write();
@@ -203,6 +203,7 @@ impl PicoDriver for PS6000Driver {
         &self,
         handle: i16,
         sample_config: &SampleConfig,
+        _enabled_channels: u8,
     ) -> PicoResult<SampleConfig> {
         let mut sample_interval = vec![sample_config.interval];
 

--- a/driver/src/resolution.rs
+++ b/driver/src/resolution.rs
@@ -1,9 +1,12 @@
+use crate::{
+    ps2000, ps2000a, ps3000a, ps4000, ps4000a, ps5000a, ps6000, ps6000a, ArcDriver, DriverLoadError,
+};
 use pico_common::Driver;
-use std::{env::current_exe, path::PathBuf};
+use std::{env::current_exe, path::PathBuf, sync::Arc};
 
 /// Instructs the loader where to load drivers from
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
-pub enum Resolution {
+pub enum LibraryResolution {
     /// Searches for drivers using the OS default path resolution
     Default,
     /// Searches for drivers in the application root directory
@@ -12,25 +15,42 @@ pub enum Resolution {
     Custom(PathBuf),
 }
 
-impl Resolution {
+impl LibraryResolution {
     /// Get the expected path for a driver for this resolution
     pub fn get_path(&self, driver: Driver) -> PathBuf {
         let binary_name = driver.get_binary_name();
 
         match self {
-            Resolution::Default => PathBuf::from(binary_name),
-            Resolution::AppRoot => current_exe()
+            LibraryResolution::Default => PathBuf::from(binary_name),
+            LibraryResolution::AppRoot => current_exe()
                 .expect("current_exe path could not be found")
                 .parent()
                 .expect("current_exe path does not have parent")
                 .join(binary_name),
-            Resolution::Custom(path) => path.join(binary_name),
+            LibraryResolution::Custom(path) => path.join(binary_name),
         }
+    }
+
+    pub fn try_load(&self, driver: Driver) -> Result<ArcDriver, DriverLoadError> {
+        let path = self.get_path(driver);
+        Ok(match driver {
+            Driver::PS2000 => Arc::new(ps2000::PS2000Driver::new(path)?),
+            Driver::PS2000A => Arc::new(ps2000a::PS2000ADriver::new(path)?),
+            Driver::PS3000A => Arc::new(ps3000a::PS3000ADriver::new(path)?),
+            Driver::PS4000 => Arc::new(ps4000::PS4000Driver::new(path)?),
+            Driver::PS4000A => Arc::new(ps4000a::PS4000ADriver::new(path)?),
+            Driver::PS5000A => Arc::new(ps5000a::PS5000ADriver::new(path)?),
+            Driver::PS6000 => Arc::new(ps6000::PS6000Driver::new(path)?),
+            Driver::PS6000A => Arc::new(ps6000a::PS6000ADriver::new(path)?),
+            Driver::PicoIPP | Driver::IOMP5 => {
+                panic!("{driver} is a library used by Pico drivers and cannot be loaded directly",)
+            }
+        })
     }
 }
 
-impl Default for Resolution {
+impl Default for LibraryResolution {
     fn default() -> Self {
-        Resolution::Default
+        LibraryResolution::Default
     }
 }

--- a/enumeration/Cargo.toml
+++ b/enumeration/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 authors = ["Tim Fish <tim@timfish.uk>"]
 description = "Unofficial Rust bindings and wrappers for Pico Technology oscilloscope drivers"
-edition = "2018"
+edition = "2021"
 keywords = ["Oscilloscope", "Streaming", "PicoScope", "Pico-Technology"]
 license = "MIT"
 name = "pico-enumeration"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.1"
+version = "0.4.0"
 
 [lib]
 crate-type = ["lib"]
@@ -15,9 +15,9 @@ path = "src/lib.rs"
 
 [dependencies]
 parking_lot = "0.11"
-pico-common = {path = "../common", version = "0.3.1"}
-pico-device = {path = "../device", version = "0.3.1"}
-pico-driver = {path = "../driver", version = "0.3.1"}
+pico-common = {path = "../common", version = "0.4.0"}
+pico-device = {path = "../device", version = "0.4.0"}
+pico-driver = {path = "../driver", version = "0.4.0"}
 rayon = "1.3"
 serde = {version = "1.0", features = ["derive"], optional = true}
 thiserror = "1.0"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 authors = ["Tim Fish <tim@timfish.uk>"]
 description = "Unofficial Rust bindings and wrappers for Pico Technology oscilloscope drivers"
-edition = "2018"
+edition = "2021"
 keywords = ["Oscilloscope", "Streaming", "PicoScope", "Pico-Technology"]
 license = "MIT"
 name = "pico-sdk"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.1"
+version = "0.4.0"
 
 [lib]
 crate-type = ["lib"]
@@ -17,13 +17,13 @@ path = "src/lib.rs"
 serde = ["pico-common/serde", "pico-device/serde", "pico-enumeration/serde", "pico-streaming/serde"]
 
 [dependencies]
-pico-common = {path = "../common", version = "0.3.1"}
-pico-device = {path = "../device", version = "0.3.1"}
-pico-download = {path = "../download", version = "0.3.1"}
-pico-driver = {path = "../driver", version = "0.3.1"}
-pico-enumeration = {path = "../enumeration", version = "0.3.1"}
-pico-streaming = {path = "../streaming", version = "0.3.1"}
-pico-sys-dynamic = {path = "../sys", version = "0.3.1"}
+pico-common = {path = "../common", version = "0.4.0"}
+pico-device = {path = "../device", version = "0.4.0"}
+pico-download = {path = "../download", version = "0.4.0"}
+pico-driver = {path = "../driver", version = "0.4.0"}
+pico-enumeration = {path = "../enumeration", version = "0.4.0"}
+pico-streaming = {path = "../streaming", version = "0.4.0"}
+pico-sys-dynamic = {path = "../sys", version = "0.4.0"}
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -58,10 +58,9 @@ Loads the specified driver and attempts open the optionally specified device ser
 ## Usage Examples
 Opening and configuring a specific ps2000 device as a `PicoDevice`:
 ```rust
-use std::sync::Arc;
 use pico_sdk::prelude::*;
 
-let driver = Driver::PS2000.try_load()?;
+let driver = LibraryResolution::Default.try_load(Driver::PS2000)?;
 let device = PicoDevice::try_open(&driver, Some("ABC/123"))?;
 ```
 

--- a/sdk/examples/open.rs
+++ b/sdk/examples/open.rs
@@ -1,4 +1,5 @@
-use pico_sdk::{common::Driver, driver::LoadDriverExt};
+use pico_driver::LibraryResolution;
+use pico_sdk::common::Driver;
 use std::{env, str::FromStr};
 
 fn main() {
@@ -11,8 +12,8 @@ fn main() {
     )
     .expect("Could not parse first argument as driver type (ie. should be similar to '4000a'");
 
-    let driver = driver_type
-        .try_load()
+    let driver = LibraryResolution::default()
+        .try_load(driver_type)
         .unwrap_or_else(|e| panic!("Failed to load {} driver: {}", driver_type, e));
 
     let serial = args.next();

--- a/sdk/examples/streaming_cli.rs
+++ b/sdk/examples/streaming_cli.rs
@@ -209,8 +209,7 @@ fn configure_channels(device: &PicoStreamingDevice) -> HashMap<PicoChannel, Stri
         if ch_selection >= channels.len() {
             return channels
                 .iter()
-                .map(|(ch, _, config)| config.map(|c| (*ch, c.range.get_units().short)))
-                .flatten()
+                .filter_map(|(ch, _, config)| config.map(|c| (*ch, c.range.get_units().short)))
                 .collect();
         }
 
@@ -280,10 +279,7 @@ impl NewDataHandler for CaptureStats {
                     *ch,
                     v.samples.len(),
                     v.scale_sample(0),
-                    self.ch_units
-                        .get(&ch)
-                        .unwrap_or(&"".to_string())
-                        .to_string(),
+                    self.ch_units.get(ch).unwrap_or(&"".to_string()).to_string(),
                 )
             })
             .collect();

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -59,10 +59,9 @@
 //! Opening and configuring a specific ps2000 device as a `PicoDevice`:
 //! ```no_run
 //! # fn run() -> Result<(),Box<dyn std::error::Error>> {
-//! use std::sync::Arc;
 //! use pico_sdk::prelude::*;
 //!
-//! let driver = Driver::PS2000.try_load()?;
+//! let driver = LibraryResolution::Default.try_load(Driver::PS2000)?;
 //! let device = PicoDevice::try_open(&driver, Some("ABC/123"))?;
 //! # Ok(())
 //! # }
@@ -146,7 +145,7 @@ pub mod prelude {
     pub use pico_device::PicoDevice;
     pub use pico_download::{cache_resolution, download_drivers_to_cache};
     pub use pico_driver::{
-        kernel_driver, DriverLoadError, EnumerationResult, LoadDriverExt, PicoDriver, Resolution,
+        kernel_driver, DriverLoadError, EnumerationResult, LibraryResolution, PicoDriver,
     };
     pub use pico_enumeration::{
         DeviceEnumerator, EnumResultHelpers, EnumeratedDevice, EnumerationError,

--- a/sdk/tests/load_drivers.rs
+++ b/sdk/tests/load_drivers.rs
@@ -1,6 +1,5 @@
 use pico_common::Driver;
 use pico_download::{cache_resolution, download_drivers_to_cache};
-use pico_driver::LoadDriverExt;
 
 #[test]
 fn load_all_drivers() {
@@ -16,12 +15,12 @@ fn load_all_drivers() {
 
     let cache_resolution = cache_resolution();
 
-    drivers.iter().for_each(|d| {
-        let mut loaded = d.try_load_with_resolution(&cache_resolution);
+    drivers.into_iter().for_each(|d| {
+        let mut loaded = cache_resolution.try_load(d);
 
         if loaded.is_err() {
-            download_drivers_to_cache(&[*d]).unwrap();
-            loaded = d.try_load_with_resolution(&cache_resolution);
+            download_drivers_to_cache(&[d]).unwrap();
+            loaded = cache_resolution.try_load(d);
         }
 
         assert!(loaded.is_ok());

--- a/streaming/Cargo.toml
+++ b/streaming/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 authors = ["Tim Fish <tim@timfish.uk>"]
 description = "Unofficial Rust bindings and wrappers for Pico Technology oscilloscope drivers"
-edition = "2018"
+edition = "2021"
 keywords = ["Oscilloscope", "Streaming", "PicoScope", "Pico-Technology"]
 license = "MIT"
 name = "pico-streaming"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.1"
+version = "0.4.0"
 
 [lib]
 crate-type = ["lib"]
@@ -16,9 +16,9 @@ path = "src/lib.rs"
 [dependencies]
 crossbeam = "0.8"
 parking_lot = {version = "0.11", features = ["serde"]}
-pico-common = {path = "../common", version = "0.3.1"}
-pico-device = {path = "../device", version = "0.3.1"}
-pico-driver = {path = "../driver", version = "0.3.1"}
+pico-common = {path = "../common", version = "0.4.0"}
+pico-device = {path = "../device", version = "0.4.0"}
+pico-driver = {path = "../driver", version = "0.4.0"}
 serde = {version = "1.0", features = ["derive", "rc"], optional = true}
 tracing = {version = "0.1", features = ["attributes"]}
 

--- a/streaming/tests/stream.rs
+++ b/streaming/tests/stream.rs
@@ -9,7 +9,7 @@ mod streaming_tests {
     use pico_device::PicoDevice;
     use pico_driver::{ArcDriver, DriverLoadError, EnumerationResult, PicoDriver};
     use pico_streaming::ToStreamDevice;
-    use std::{pin::Pin, sync::Arc, thread, time::Duration};
+    use std::{sync::Arc, thread, time::Duration};
 
     mock! {
         MockDriver {}
@@ -39,13 +39,14 @@ mod streaming_tests {
                 &self,
                 handle: i16,
                 channel: PicoChannel,
-                buffer: Arc<RwLock<Pin<Vec<i16>>>>,
+                buffer: Arc<RwLock<Vec<i16>>>,
                 buffer_len: usize,
             ) -> PicoResult<()>;
             fn start_streaming(
                 &self,
                 handle: i16,
                 sample_config: &SampleConfig,
+                enabled_channels: u8
             ) -> PicoResult<SampleConfig>;
             fn get_latest_streaming_values<'a>(
                 &self,

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 authors = ["Tim Fish <tim@timfish.uk>"]
 description = "Unofficial Rust bindings and wrappers for Pico Technology oscilloscope drivers"
-edition = "2018"
+edition = "2021"
 keywords = ["Oscilloscope", "Streaming", "PicoScope", "Pico-Technology"]
 license = "MIT"
 name = "pico-sys-dynamic"
 readme = "README.md"
 repository = "https://github.com/meatysolutions/pico-sdk"
-version = "0.3.1"
+version = "0.4.0"
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
- Update edition to 2021
- Fix new clippy lints
- Rename `Resolution` to `LibraryResolution`
- Add `LibraryResolution::try_load` to load a driver rather than `Driver::PS2000::try_load`
- For variable resolution devices, auto select highest resolution for number of enabled channels