### PR TITLE
allow setting the channel offset

### DIFF
--- a/sdk/examples/streaming_cli.rs
+++ b/sdk/examples/streaming_cli.rs
@@ -226,7 +226,7 @@ fn configure_channels(device: &PicoStreamingDevice) -> HashMap<PicoChannel, Stri
             }
 
             if let Some(range) = select_range(&ranges) {
-                device.enable_channel(edit_channel, range, PicoCoupling::DC);
+                device.enable_channel(edit_channel, range, PicoCoupling::DC, 0.0);
             } else {
                 device.disable_channel(edit_channel);
             }

--- a/streaming/src/lib.rs
+++ b/streaming/src/lib.rs
@@ -215,13 +215,13 @@ impl PicoStreamingDevice {
         self.device.variant.to_string()
     }
 
-    pub fn enable_channel(&self, channel: PicoChannel, range: PicoRange, coupling: PicoCoupling) {
+    pub fn enable_channel(&self, channel: PicoChannel, range: PicoRange, coupling: PicoCoupling, offset: f64) {
         self.enabled_channels.write().insert(
             channel,
             ChannelConfig {
                 range,
                 coupling,
-                offset: 0.0,
+                offset,
             },
         );
     }


### PR DESCRIPTION
This is the easiest way of allowing a client to set the channel offset.