### PR TITLE
feat: Add pl1000 sys bindings

### DIFF
--- a/common/src/driver.rs
+++ b/common/src/driver.rs
@@ -80,6 +80,7 @@ impl Driver {
             0x1215 | 0x1216 | 0x12A0 | 0x12A1 => Some(Driver::PS6000A),
             0x1020 => Some(Driver::PSOSPA),
             0x1000 => Some(Driver::TC08),
+            0x100C => Some(Driver::PL1000),
             u => {
                 tracing::warn!("Unsupported Pico Product ID found: {:#X}", u);
                 None

--- a/common/src/driver.rs
+++ b/common/src/driver.rs
@@ -19,6 +19,8 @@ pub enum Driver {
     PS6000,
     PS6000A,
     PSOSPA,
+    /// PicoLog 1000 series data logger
+    PL1000,
     /// USB TC-08 thermocouple data logger
     TC08,
     /// Not a device driver: a shared library that ps4000 and ps6000 load at runtime
@@ -45,6 +47,7 @@ impl FromStr for Driver {
             "6000" => Ok(Driver::PS6000),
             "6000A" => Ok(Driver::PS6000A),
             "OSPA" => Ok(Driver::PSOSPA),
+            "PL1000" => Ok(Driver::PL1000),
             "TC08" => Ok(Driver::TC08),
             _ => Err(ParseError),
         }
@@ -99,7 +102,7 @@ impl Driver {
             | Driver::PS6000
             | Driver::PS6000A
             | Driver::PSOSPA => true,
-            Driver::TC08 | Driver::PicoIPP => false,
+            Driver::PL1000 | Driver::TC08 | Driver::PicoIPP => false,
         }
     }
 
@@ -168,6 +171,8 @@ mod tests {
         assert_eq!(Driver::from_str("ps2000a"), Ok(Driver::PS2000A));
         assert_eq!(Driver::from_str("PS 5000A"), Ok(Driver::PS5000A));
         assert_eq!(Driver::from_str("psospa"), Ok(Driver::PSOSPA));
+        assert_eq!(Driver::from_str("pl1000"), Ok(Driver::PL1000));
+        assert_eq!(Driver::from_str("PL1000"), Ok(Driver::PL1000));
         assert_eq!(Driver::from_str("usbtc08"), Ok(Driver::TC08));
         assert_eq!(Driver::from_str("TC-08"), Ok(Driver::TC08));
         assert_eq!(Driver::from_str("nonsense"), Err(ParseError));
@@ -179,10 +184,16 @@ mod tests {
     }
 
     #[test]
+    fn pl1000_binary_is_named_pl1000() {
+        assert!(Driver::PL1000.get_binary_name().contains("pl1000"));
+    }
+
+    #[test]
     fn every_driver_is_classified_as_scope_or_not() {
         // `is_scope` is an exhaustive match, so this is really a compile-time guarantee. The
         // assertions pin the two families so a mis-sorted new variant shows up as a test failure.
         assert!(Driver::PSOSPA.is_scope());
         assert!(!Driver::TC08.is_scope());
+        assert!(!Driver::PL1000.is_scope());
     }
 }

--- a/download/examples/generate-manifest.rs
+++ b/download/examples/generate-manifest.rs
@@ -279,6 +279,7 @@ fn lib_of(file_name: &str) -> &str {
 /// runtime, so it has to travel with them.
 fn driver_for(lib: &str) -> Option<Driver> {
     Some(match lib {
+        "pl1000" => Driver::PL1000,
         "ps2000" => Driver::PS2000,
         "ps2000a" => Driver::PS2000A,
         "ps3000a" => Driver::PS3000A,

--- a/driver/src/resolution.rs
+++ b/driver/src/resolution.rs
@@ -77,6 +77,9 @@ impl DriverLoad for Driver {
             Driver::PicoIPP => {
                 panic!("{self} is a library used by Pico drivers and cannot be loaded directly",)
             }
+            Driver::PL1000 => {
+                panic!("{self} does not yet have a safe wrapper in the pico-driver crate")
+            }
         })
     }
 }

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -13,6 +13,7 @@
 //! let handle = unsafe { ps2000.ps2000_open_unit() };
 //! ```
 
+pub mod pl1000;
 pub mod ps2000;
 pub mod ps2000a;
 pub mod ps3000;
@@ -25,3 +26,21 @@ pub mod ps6000;
 pub mod ps6000a;
 pub mod psospa;
 pub mod tc08;
+
+#[cfg(test)]
+mod tests {
+    /// Proves the generated `pl1000` module compiles, exports its loader type, and its constants
+    /// match the values published in `pl1000Api.h`. No hardware is required.
+    #[test]
+    fn pl1000_module_exports_expected_items() {
+        use crate::pl1000::{PL1000Loader, PL1000_MAX_PERIOD, PL1000_MIN_PERIOD};
+
+        assert_eq!(PL1000_MIN_PERIOD, 100);
+        assert_eq!(PL1000_MAX_PERIOD, 1800);
+
+        // The loader type must exist and be constructible from a `libloading::Library`; we don't
+        // load a real driver here since none is guaranteed to be present in CI.
+        fn _type_check(_: fn(::libloading::Library) -> Result<PL1000Loader, ::libloading::Error>) {}
+        _type_check(|lib| unsafe { PL1000Loader::from_library(lib) });
+    }
+}

--- a/sys/src/pl1000.rs
+++ b/sys/src/pl1000.rs
@@ -1,0 +1,363 @@
+pub const PL1000_MIN_PERIOD: u32 = 100;
+pub const PL1000_MAX_PERIOD: u32 = 1800;
+pub type PICO_INFO = u32;
+pub type PICO_STATUS = u32;
+pub const enPL1000Inputs_PL1000_CHANNEL_1: enPL1000Inputs = 1;
+pub const enPL1000Inputs_PL1000_CHANNEL_2: enPL1000Inputs = 2;
+pub const enPL1000Inputs_PL1000_CHANNEL_3: enPL1000Inputs = 3;
+pub const enPL1000Inputs_PL1000_CHANNEL_4: enPL1000Inputs = 4;
+pub const enPL1000Inputs_PL1000_CHANNEL_5: enPL1000Inputs = 5;
+pub const enPL1000Inputs_PL1000_CHANNEL_6: enPL1000Inputs = 6;
+pub const enPL1000Inputs_PL1000_CHANNEL_7: enPL1000Inputs = 7;
+pub const enPL1000Inputs_PL1000_CHANNEL_8: enPL1000Inputs = 8;
+pub const enPL1000Inputs_PL1000_CHANNEL_9: enPL1000Inputs = 9;
+pub const enPL1000Inputs_PL1000_CHANNEL_10: enPL1000Inputs = 10;
+pub const enPL1000Inputs_PL1000_CHANNEL_11: enPL1000Inputs = 11;
+pub const enPL1000Inputs_PL1000_CHANNEL_12: enPL1000Inputs = 12;
+pub const enPL1000Inputs_PL1000_CHANNEL_13: enPL1000Inputs = 13;
+pub const enPL1000Inputs_PL1000_CHANNEL_14: enPL1000Inputs = 14;
+pub const enPL1000Inputs_PL1000_CHANNEL_15: enPL1000Inputs = 15;
+pub const enPL1000Inputs_PL1000_CHANNEL_16: enPL1000Inputs = 16;
+pub const enPL1000Inputs_PL1000_MAX_CHANNELS: enPL1000Inputs = 16;
+pub type enPL1000Inputs = ::std::os::raw::c_uint;
+pub use self::enPL1000Inputs as PL1000_INPUTS;
+pub const enPL1000DO_Channel_PL1000_DO_CHANNEL_0: enPL1000DO_Channel = 0;
+pub const enPL1000DO_Channel_PL1000_DO_CHANNEL_1: enPL1000DO_Channel = 1;
+pub const enPL1000DO_Channel_PL1000_DO_CHANNEL_2: enPL1000DO_Channel = 2;
+pub const enPL1000DO_Channel_PL1000_DO_CHANNEL_3: enPL1000DO_Channel = 3;
+pub const enPL1000DO_Channel_PL1000_DO_CHANNEL_MAX: enPL1000DO_Channel = 4;
+pub type enPL1000DO_Channel = ::std::os::raw::c_uint;
+pub use self::enPL1000DO_Channel as PL1000_DO_CH;
+pub const enPL1000OpenProgress_PL1000_OPEN_PROGRESS_FAIL: enPL1000OpenProgress = -1;
+pub const enPL1000OpenProgress_PL1000_OPEN_PROGRESS_PENDING: enPL1000OpenProgress = 0;
+pub const enPL1000OpenProgress_PL1000_OPEN_PROGRESS_COMPLETE: enPL1000OpenProgress = 1;
+pub type enPL1000OpenProgress = ::std::os::raw::c_int;
+pub use self::enPL1000OpenProgress as PL1000_OPEN_PROGRESS;
+pub const _BLOCK_METHOD_BM_SINGLE: _BLOCK_METHOD = 0;
+pub const _BLOCK_METHOD_BM_WINDOW: _BLOCK_METHOD = 1;
+pub const _BLOCK_METHOD_BM_STREAM: _BLOCK_METHOD = 2;
+pub type _BLOCK_METHOD = ::std::os::raw::c_uint;
+pub use self::_BLOCK_METHOD as BLOCK_METHOD;
+pub struct PL1000Loader {
+    __library: ::libloading::Library,
+    pub pl1000OpenUnit:
+        Result<unsafe extern "C" fn(handle: *mut i16) -> PICO_STATUS, ::libloading::Error>,
+    pub pl1000CloseUnit:
+        Result<unsafe extern "C" fn(handle: i16) -> PICO_STATUS, ::libloading::Error>,
+    pub pl1000GetUnitInfo: Result<
+        unsafe extern "C" fn(
+            handle: i16,
+            string: *mut i8,
+            stringLength: i16,
+            requiredSize: *mut i16,
+            info: PICO_INFO,
+        ) -> PICO_STATUS,
+        ::libloading::Error,
+    >,
+    pub pl1000SetDo: Result<
+        unsafe extern "C" fn(handle: i16, do_value: i16, doNo: i16) -> PICO_STATUS,
+        ::libloading::Error,
+    >,
+    pub pl1000SetPulseWidth: Result<
+        unsafe extern "C" fn(handle: i16, period: u16, cycle: u8) -> PICO_STATUS,
+        ::libloading::Error,
+    >,
+    pub pl1000Run: Result<
+        unsafe extern "C" fn(handle: i16, no_of_values: u32, method: BLOCK_METHOD) -> PICO_STATUS,
+        ::libloading::Error,
+    >,
+    pub pl1000Ready: Result<
+        unsafe extern "C" fn(handle: i16, ready: *mut i16) -> PICO_STATUS,
+        ::libloading::Error,
+    >,
+    pub pl1000Stop: Result<unsafe extern "C" fn(handle: i16) -> PICO_STATUS, ::libloading::Error>,
+    pub pl1000MaxValue: Result<
+        unsafe extern "C" fn(handle: i16, maxValue: *mut u16) -> PICO_STATUS,
+        ::libloading::Error,
+    >,
+    pub pl1000SetInterval: Result<
+        unsafe extern "C" fn(
+            handle: i16,
+            us_for_block: *mut u32,
+            ideal_no_of_samples: u32,
+            channels: *mut i16,
+            no_of_channels: i16,
+        ) -> PICO_STATUS,
+        ::libloading::Error,
+    >,
+    pub pl1000SetTrigger: Result<
+        unsafe extern "C" fn(
+            handle: i16,
+            enabled: u16,
+            auto_trigger: u16,
+            auto_ms: u16,
+            channel: u16,
+            dir: u16,
+            threshold: u16,
+            hysterisis: u16,
+            delay: f32,
+        ) -> PICO_STATUS,
+        ::libloading::Error,
+    >,
+    pub pl1000GetValues: Result<
+        unsafe extern "C" fn(
+            handle: i16,
+            values: *mut u16,
+            noOfValues: *mut u32,
+            overflow: *mut u16,
+            triggerIndex: *mut u32,
+        ) -> PICO_STATUS,
+        ::libloading::Error,
+    >,
+    pub pl1000GetTriggerTimeOffsetNs: Result<
+        unsafe extern "C" fn(handle: i16, time: *mut i64) -> PICO_STATUS,
+        ::libloading::Error,
+    >,
+    pub pl1000GetSingle: Result<
+        unsafe extern "C" fn(handle: i16, channel: PL1000_INPUTS, value: *mut u16) -> PICO_STATUS,
+        ::libloading::Error,
+    >,
+    pub pl1000OpenUnitAsync:
+        Result<unsafe extern "C" fn(status: *mut i16) -> PICO_STATUS, ::libloading::Error>,
+    pub pl1000OpenUnitProgress: Result<
+        unsafe extern "C" fn(
+            handle: *mut i16,
+            progress: *mut i16,
+            complete: *mut i16,
+        ) -> PICO_STATUS,
+        ::libloading::Error,
+    >,
+    pub pl1000PingUnit:
+        Result<unsafe extern "C" fn(handle: i16) -> PICO_STATUS, ::libloading::Error>,
+}
+impl PL1000Loader {
+    pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+    where
+        P: AsRef<::std::ffi::OsStr>,
+    {
+        let library = ::libloading::Library::new(path)?;
+        Self::from_library(library)
+    }
+    pub unsafe fn from_library<L>(library: L) -> Result<Self, ::libloading::Error>
+    where
+        L: Into<::libloading::Library>,
+    {
+        let __library = library.into();
+        let pl1000OpenUnit = __library.get(b"pl1000OpenUnit\0").map(|sym| *sym);
+        let pl1000CloseUnit = __library.get(b"pl1000CloseUnit\0").map(|sym| *sym);
+        let pl1000GetUnitInfo = __library.get(b"pl1000GetUnitInfo\0").map(|sym| *sym);
+        let pl1000SetDo = __library.get(b"pl1000SetDo\0").map(|sym| *sym);
+        let pl1000SetPulseWidth = __library.get(b"pl1000SetPulseWidth\0").map(|sym| *sym);
+        let pl1000Run = __library.get(b"pl1000Run\0").map(|sym| *sym);
+        let pl1000Ready = __library.get(b"pl1000Ready\0").map(|sym| *sym);
+        let pl1000Stop = __library.get(b"pl1000Stop\0").map(|sym| *sym);
+        let pl1000MaxValue = __library.get(b"pl1000MaxValue\0").map(|sym| *sym);
+        let pl1000SetInterval = __library.get(b"pl1000SetInterval\0").map(|sym| *sym);
+        let pl1000SetTrigger = __library.get(b"pl1000SetTrigger\0").map(|sym| *sym);
+        let pl1000GetValues = __library.get(b"pl1000GetValues\0").map(|sym| *sym);
+        let pl1000GetTriggerTimeOffsetNs = __library
+            .get(b"pl1000GetTriggerTimeOffsetNs\0")
+            .map(|sym| *sym);
+        let pl1000GetSingle = __library.get(b"pl1000GetSingle\0").map(|sym| *sym);
+        let pl1000OpenUnitAsync = __library.get(b"pl1000OpenUnitAsync\0").map(|sym| *sym);
+        let pl1000OpenUnitProgress = __library.get(b"pl1000OpenUnitProgress\0").map(|sym| *sym);
+        let pl1000PingUnit = __library.get(b"pl1000PingUnit\0").map(|sym| *sym);
+        Ok(PL1000Loader {
+            __library,
+            pl1000OpenUnit,
+            pl1000CloseUnit,
+            pl1000GetUnitInfo,
+            pl1000SetDo,
+            pl1000SetPulseWidth,
+            pl1000Run,
+            pl1000Ready,
+            pl1000Stop,
+            pl1000MaxValue,
+            pl1000SetInterval,
+            pl1000SetTrigger,
+            pl1000GetValues,
+            pl1000GetTriggerTimeOffsetNs,
+            pl1000GetSingle,
+            pl1000OpenUnitAsync,
+            pl1000OpenUnitProgress,
+            pl1000PingUnit,
+        })
+    }
+    pub unsafe fn pl1000OpenUnit(&self, handle: *mut i16) -> PICO_STATUS {
+        (self
+            .pl1000OpenUnit
+            .as_ref()
+            .expect("Expected function, got error."))(handle)
+    }
+    pub unsafe fn pl1000CloseUnit(&self, handle: i16) -> PICO_STATUS {
+        (self
+            .pl1000CloseUnit
+            .as_ref()
+            .expect("Expected function, got error."))(handle)
+    }
+    pub unsafe fn pl1000GetUnitInfo(
+        &self,
+        handle: i16,
+        string: *mut i8,
+        stringLength: i16,
+        requiredSize: *mut i16,
+        info: PICO_INFO,
+    ) -> PICO_STATUS {
+        (self
+            .pl1000GetUnitInfo
+            .as_ref()
+            .expect("Expected function, got error."))(
+            handle,
+            string,
+            stringLength,
+            requiredSize,
+            info,
+        )
+    }
+    pub unsafe fn pl1000SetDo(&self, handle: i16, do_value: i16, doNo: i16) -> PICO_STATUS {
+        (self
+            .pl1000SetDo
+            .as_ref()
+            .expect("Expected function, got error."))(handle, do_value, doNo)
+    }
+    pub unsafe fn pl1000SetPulseWidth(&self, handle: i16, period: u16, cycle: u8) -> PICO_STATUS {
+        (self
+            .pl1000SetPulseWidth
+            .as_ref()
+            .expect("Expected function, got error."))(handle, period, cycle)
+    }
+    pub unsafe fn pl1000Run(
+        &self,
+        handle: i16,
+        no_of_values: u32,
+        method: BLOCK_METHOD,
+    ) -> PICO_STATUS {
+        (self
+            .pl1000Run
+            .as_ref()
+            .expect("Expected function, got error."))(handle, no_of_values, method)
+    }
+    pub unsafe fn pl1000Ready(&self, handle: i16, ready: *mut i16) -> PICO_STATUS {
+        (self
+            .pl1000Ready
+            .as_ref()
+            .expect("Expected function, got error."))(handle, ready)
+    }
+    pub unsafe fn pl1000Stop(&self, handle: i16) -> PICO_STATUS {
+        (self
+            .pl1000Stop
+            .as_ref()
+            .expect("Expected function, got error."))(handle)
+    }
+    pub unsafe fn pl1000MaxValue(&self, handle: i16, maxValue: *mut u16) -> PICO_STATUS {
+        (self
+            .pl1000MaxValue
+            .as_ref()
+            .expect("Expected function, got error."))(handle, maxValue)
+    }
+    pub unsafe fn pl1000SetInterval(
+        &self,
+        handle: i16,
+        us_for_block: *mut u32,
+        ideal_no_of_samples: u32,
+        channels: *mut i16,
+        no_of_channels: i16,
+    ) -> PICO_STATUS {
+        (self
+            .pl1000SetInterval
+            .as_ref()
+            .expect("Expected function, got error."))(
+            handle,
+            us_for_block,
+            ideal_no_of_samples,
+            channels,
+            no_of_channels,
+        )
+    }
+    pub unsafe fn pl1000SetTrigger(
+        &self,
+        handle: i16,
+        enabled: u16,
+        auto_trigger: u16,
+        auto_ms: u16,
+        channel: u16,
+        dir: u16,
+        threshold: u16,
+        hysterisis: u16,
+        delay: f32,
+    ) -> PICO_STATUS {
+        (self
+            .pl1000SetTrigger
+            .as_ref()
+            .expect("Expected function, got error."))(
+            handle,
+            enabled,
+            auto_trigger,
+            auto_ms,
+            channel,
+            dir,
+            threshold,
+            hysterisis,
+            delay,
+        )
+    }
+    pub unsafe fn pl1000GetValues(
+        &self,
+        handle: i16,
+        values: *mut u16,
+        noOfValues: *mut u32,
+        overflow: *mut u16,
+        triggerIndex: *mut u32,
+    ) -> PICO_STATUS {
+        (self
+            .pl1000GetValues
+            .as_ref()
+            .expect("Expected function, got error."))(
+            handle,
+            values,
+            noOfValues,
+            overflow,
+            triggerIndex,
+        )
+    }
+    pub unsafe fn pl1000GetTriggerTimeOffsetNs(&self, handle: i16, time: *mut i64) -> PICO_STATUS {
+        (self
+            .pl1000GetTriggerTimeOffsetNs
+            .as_ref()
+            .expect("Expected function, got error."))(handle, time)
+    }
+    pub unsafe fn pl1000GetSingle(
+        &self,
+        handle: i16,
+        channel: PL1000_INPUTS,
+        value: *mut u16,
+    ) -> PICO_STATUS {
+        (self
+            .pl1000GetSingle
+            .as_ref()
+            .expect("Expected function, got error."))(handle, channel, value)
+    }
+    pub unsafe fn pl1000OpenUnitAsync(&self, status: *mut i16) -> PICO_STATUS {
+        (self
+            .pl1000OpenUnitAsync
+            .as_ref()
+            .expect("Expected function, got error."))(status)
+    }
+    pub unsafe fn pl1000OpenUnitProgress(
+        &self,
+        handle: *mut i16,
+        progress: *mut i16,
+        complete: *mut i16,
+    ) -> PICO_STATUS {
+        (self
+            .pl1000OpenUnitProgress
+            .as_ref()
+            .expect("Expected function, got error."))(handle, progress, complete)
+    }
+    pub unsafe fn pl1000PingUnit(&self, handle: i16) -> PICO_STATUS {
+        (self
+            .pl1000PingUnit
+            .as_ref()
+            .expect("Expected function, got error."))(handle)
+    }
+}


### PR DESCRIPTION
Dynamically-loaded bindgen bindings for the PicoLog 1000 series data logger.

- `sys/src/pl1000.rs` generated from the officially installed published header (`PicoSDK.framework/Headers`), bindgen 0.69.5, `--dynamic-loading` + `--no-layout-tests`, banner/`extern crate` mechanically stripped to match existing modules
- `Driver` enum variant + `from_str`/Display/`is_scope` wiring and tests
- USB PID `0x100C` (VID `0x0CE9`) for enumeration, sourced from Pico's publicly distributed Windows driver package (picowinusb.inf)
- `generate-manifest` mapping so the next driver-bundle regeneration publishes the binaries
- `driver/src/resolution.rs`: stub arm (no high-level wrapper yet, mirrors PicoIPP precedent)

Note: all five logger PRs add one-line entries to the same few files — expect trivial conflicts after the first merge; `resolution.rs` arms should all be kept.